### PR TITLE
Use case-sensitive path to plugin js file

### DIFF
--- a/example/www/index.html
+++ b/example/www/index.html
@@ -33,7 +33,7 @@
 	-->
 	<!-- If your application is targeting iOS BEFORE 4.0 you MUST put json2.js from http://www.JSON.org/json2.js into your www directory and include it here -->
 	<script type="text/javascript" charset="utf-8" src="cordova-2.3.0.js"></script>
-    <script type="text/javascript" charset="utf-8" src="phonegap/plugin/localNotification/LocalNotification.js"></script>
+    <script type="text/javascript" charset="utf-8" src="phonegap/plugin/localNotification/localNotification.js"></script>
     <script type="text/javascript">
 
 


### PR DESCRIPTION
When I tried to run the example app locally it didn't work because it had the wrong case for the javascript file. This PR fixes that. cc @lauren
